### PR TITLE
feat: Added restart command for Minecraft

### DIFF
--- a/src/minecraft_monitor.py
+++ b/src/minecraft_monitor.py
@@ -63,7 +63,12 @@ class MinecraftMonitor(GameMonitor):
         while self.server_running:
             time.sleep(self.config["heartbeat"])
         self.logger.debug("Server has shutdown.")
-        return True
+
+    def restart_game_server(self):
+        self.logger.debug("Starting server restart sequence.")
+        self.shutdown_game_server()
+        self.logger.debug("Server successfully shutdown. Continuing with restarting server.")
+        self.start_game_server()
 
     @property
     def server_empty(self):

--- a/src/minecraft_monitor.py
+++ b/src/minecraft_monitor.py
@@ -42,6 +42,9 @@ class MinecraftMonitor(GameMonitor):
         elif "stop" in command_words:
             self.shutdown_game_server()
             return "Server has shutdown."
+        elif "restart" in command_words:
+            self.restart_game_server()
+            return "Server is restarting."
         elif "echo" in command_words:
             return command
         else:

--- a/src/minecraft_monitor.py
+++ b/src/minecraft_monitor.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import pathlib
+import time
 
 import sys
 from pathlib import Path
@@ -59,6 +60,10 @@ class MinecraftMonitor(GameMonitor):
         # Issue commands to the tmux session
         self.logger.debug("Shutting down game server")
         tmux_sendkeys(self.tmux_session_name, "stop")
+        while self.server_running:
+            time.sleep(self.config["heartbeat"])
+        self.logger.debug("Server has shutdown.")
+        return True
 
     @property
     def server_empty(self):

--- a/src/minecraft_monitor.py
+++ b/src/minecraft_monitor.py
@@ -64,6 +64,8 @@ class MinecraftMonitor(GameMonitor):
             time.sleep(self.config["heartbeat"])
         self.logger.debug("Server has shutdown.")
 
+    # TODO: This might be better as a method in the base class.
+    # You'd have to make sure the shutdown method waits until it's actually shutdown though.
     def restart_game_server(self):
         self.logger.debug("Starting server restart sequence.")
         self.shutdown_game_server()


### PR DESCRIPTION
This PR adds a method for restarting the Minecraft server, and updates the
command parser to be able to look for the "restart" keyword.

Test Plan:
I don't know how to test this.