### PR TITLE
refactor: Move parsing of base commands to base class

### DIFF
--- a/src/factorio_monitor.py
+++ b/src/factorio_monitor.py
@@ -36,21 +36,6 @@ class FactorioMonitor(GameMonitor):
         time.sleep(5.0)
         tmux_sendkeys(self.tmux_session_name, '/quit')
 
-    def parse_command(self, command: str):
-        command_words = command.split()
-        if "start" in command_words:
-            if self.server_running:
-                return "Server started successfully."
-            else:
-                return "Error: server did not start successfully."
-        elif "stop" in command_words:
-            self.shutdown_game_server()
-            return "Server has shutdown."
-        elif "echo" in command_words:
-            return command
-        else:
-            return 'Command not recognized.'
-
     @property
     def server_empty(self):
         # The number of lines back in the log to use to evaluate the number of players online

--- a/src/minecraft_monitor.py
+++ b/src/minecraft_monitor.py
@@ -5,7 +5,7 @@ import time
 
 import sys
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 sys.path.append(".")
 
@@ -31,25 +31,12 @@ class MinecraftMonitor(GameMonitor):
             logging.FileHandler(self.config['log_file'])
         )
 
-    def parse_command(self, command: str):
-        command_words = command.split()
-        if "start" in command_words:
-            if self.server_running:
-                return "Server started successfully."
-            else:
-                self.logger.error("Server failed to start")
-                return "Error: server did not start successfully."
-        elif "stop" in command_words:
-            self.shutdown_game_server()
-            return "Server has shutdown."
-        elif "restart" in command_words:
+    def parse_custom_commands(self, command_words: List[str]):
+        if "restart" in command_words:
             self.restart_game_server()
-            return "Server is restarting."
-        elif "echo" in command_words:
-            return command
+            return True, "Server is restarting."
         else:
-            self.logger.warning("Unrecognized command")
-            return 'Command not recognized.'
+            return False, ""
 
     def start_game_server(self):
         self.logger.debug("Starting game server")

--- a/src/server_monitor.py
+++ b/src/server_monitor.py
@@ -6,7 +6,7 @@ import os
 import time
 from pathlib import Path
 
-from typing import Type, Union
+from typing import List, Union
 
 from src.constants import REQUEST_PATH, RESPONSE_PATH, CONFIRM_PATH
 from src.utils import get_now_str, Timer, json_from_file, json_to_file
@@ -16,9 +16,25 @@ class GameMonitor(ABC):
     def __init__(self, debug_mode):
         self.debug_mode = debug_mode
 
-    @abstractmethod
+    # TODO: Add in mocked base logger
     def parse_command(self, command: str):
-        raise NotImplementedError
+        command_words = command.split()
+        custom_command_parsed, custom_command_message = self.parse_custom_commands(command_words)
+
+        if custom_command_parsed:
+            return custom_command_message
+        elif "start" in command_words:
+            if self.server_running:
+                return "Server started successfully."
+            else:
+                return "Error: server did not start successfully."
+        elif "stop" in command_words:
+            self.shutdown_game_server()
+            return "Server has shutdown."
+        elif "echo" in command_words:
+            return command
+        else:
+            return 'Command not recognized.'
 
     @abstractmethod
     def start_game_server(self):

--- a/src/server_monitor.py
+++ b/src/server_monitor.py
@@ -36,6 +36,14 @@ class GameMonitor(ABC):
         else:
             return 'Command not recognized.'
 
+    def parse_custom_commands(self, command_words: List[str]):
+        """Parse any custom commands besides the base commands.
+
+        Returns:
+            A tuple of whether there was a command that fit, and the response to return
+            """
+        return False, ""
+
     @abstractmethod
     def start_game_server(self):
         raise NotImplementedError


### PR DESCRIPTION
There's a little code duplication between the Factorio and Minecraft servers,
because parsing the commands are very similar. This PR moves that parsing logic
to the base class. However, we still want people to be able to define custom
commands of their own. To that end, I added a method for parsing custom
commands. An example of this can be seen with the Minecraft monitor, where the
restart command is added as a custom command.

Test Plan:
Probably will test this tomorrow.